### PR TITLE
Use N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,10 +2,18 @@
   "targets": [
     {
       "target_name": "fschanges",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [ "src/FSChanges.cc" ],
-      "include_dirs" : [
-        "<!(node -e \"require('nan')\")"
-      ],
+      "include_dirs" : ["<!@(node -p \"require('node-addon-api').include\")"],
+      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
       "conditions": [
         ['OS=="mac"', {
           "variables": {

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,18 +2,10 @@
   "targets": [
     {
       "target_name": "fschanges",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "10.7",
-      },
-      "msvs_settings": {
-        "VCCLCompilerTool": { "ExceptionHandling": 1 },
-      },
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
       "sources": [ "src/FSChanges.cc" ],
       "include_dirs" : ["<!@(node -p \"require('node-addon-api').include\")"],
-      'dependencies': ["<!(node -p \"require('node-addon-api').gyp\")"],
+      "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       "conditions": [
         ['OS=="mac"', {
           "variables": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "build/Release/fschanges.node",
   "dependencies": {
-    "nan": "^2.12.1"
+    "node-addon-api": "^1.6.2"
   }
 }

--- a/src/Event.hh
+++ b/src/Event.hh
@@ -14,11 +14,11 @@ struct Event {
     mType = type;
   }
 
-  Napi::Value toJS(const Napi::Env& env) {
-    Napi::EscapableHandleScope scope(env);
-    Napi::Object res = Napi::Object::New(env);
-    res.Set(Napi::String::New(env, "path"), Napi::String::New(env, mPath.c_str()));
-    res.Set(Napi::String::New(env, "type"), Napi::String::New(env, mType.c_str()));
+  Value toJS(const Env& env) {
+    EscapableHandleScope scope(env);
+    Object res = Object::New(env);
+    res.Set(String::New(env, "path"), String::New(env, mPath.c_str()));
+    res.Set(String::New(env, "type"), String::New(env, mType.c_str()));
     return scope.Escape(res);
   }
 };
@@ -31,9 +31,9 @@ public:
     mEvents.push_back(new Event(path, type));
   }
 
-  Napi::Value toJS(const Napi::Env& env) {
-    Napi::EscapableHandleScope scope(env);
-    Napi::Array arr = Napi::Array::New(env, mEvents.size());
+  Value toJS(const Env& env) {
+    EscapableHandleScope scope(env);
+    Array arr = Array::New(env, mEvents.size());
 
     for (size_t i = 0; i < mEvents.size(); i++) {
       arr.Set(i, mEvents[i]->toJS(env));

--- a/src/Event.hh
+++ b/src/Event.hh
@@ -3,9 +3,6 @@
 
 #include <string>
 #include <napi.h>
-#include <uv.h>
-#include <v8.h>
-#include <napi.h>
 
 using namespace Napi;
 

--- a/src/Event.hh
+++ b/src/Event.hh
@@ -2,12 +2,12 @@
 #define EVENT_H
 
 #include <string>
-#include <node.h>
+#include <napi.h>
 #include <uv.h>
 #include <v8.h>
-#include <nan.h>
+#include <napi.h>
 
-using namespace v8;
+using namespace Napi;
 
 struct Event {
   std::string mPath;
@@ -17,11 +17,11 @@ struct Event {
     mType = type;
   }
 
-  Local<Object> toJS() {
-    Nan::EscapableHandleScope scope;
-    Local<Object> res = Nan::New<Object>();
-    res->Set(Nan::New<String>("path").ToLocalChecked(), Nan::New<String>(mPath.c_str()).ToLocalChecked());
-    res->Set(Nan::New<String>("type").ToLocalChecked(), Nan::New<String>(mType.c_str()).ToLocalChecked());
+  Napi::Value toJS(const Napi::Env& env) {
+    Napi::EscapableHandleScope scope(env);
+    Napi::Object res = Napi::Object::New(env);
+    res.Set(Napi::String::New(env, "path"), Napi::String::New(env, mPath.c_str()));
+    res.Set(Napi::String::New(env, "type"), Napi::String::New(env, mType.c_str()));
     return scope.Escape(res);
   }
 };
@@ -34,12 +34,12 @@ public:
     mEvents.push_back(new Event(path, type));
   }
 
-  Local<Array> toJS() {
-    Nan::EscapableHandleScope scope;
-    Local<Array> arr = Nan::New<Array>(mEvents.size());
+  Napi::Value toJS(const Napi::Env& env) {
+    Napi::EscapableHandleScope scope(env);
+    Napi::Array arr = Napi::Array::New(env, mEvents.size());
 
     for (size_t i = 0; i < mEvents.size(); i++) {
-      arr->Set(i, mEvents[i]->toJS());
+      arr.Set(i, mEvents[i]->toJS(env));
     }
 
     return scope.Escape(arr);

--- a/src/FSChanges.cc
+++ b/src/FSChanges.cc
@@ -8,16 +8,25 @@
 void writeSnapshotImpl(std::string *dir, std::string *snapshotPath, std::unordered_set<std::string> *ignore);
 EventList *getEventsSinceImpl(std::string *dir, std::string *snapshotPath, std::unordered_set<std::string> *ignore);
 
-class AsyncRunner {
+class FSAsyncRunner;
+typedef void (*AsyncFunction)(FSAsyncRunner *);
+
+class FSAsyncRunner {
 public:
-  void Queue() {
-    if(this->work) {
-      napi_status status = napi_queue_async_work(env, this->work);
-      NAPI_THROW_IF_FAILED_VOID(env, status);
-    }
-  }
-protected:
-  AsyncRunner(Napi::Env env): env(env) {
+  const Napi::Env env;
+
+  std::string directory;
+  std::string snapshotPath;
+  std::string backend;
+
+  std::unordered_set<std::string> ignore;
+  EventList *events;
+
+  FSAsyncRunner(Napi::Env env, Napi::Value dir, Napi::Value snap, Napi::Value opts, Napi::Promise::Deferred r, AsyncFunction func)
+    : env(env), directory(std::string(dir.As<Napi::String>().Utf8Value().c_str())),
+      snapshotPath(std::string(snap.As<Napi::String>().Utf8Value().c_str())),
+      events(nullptr), func(func), deferred(r) {
+
     napi_status status = napi_create_async_work(env, nullptr, env.Undefined(), 
                                                 OnExecute, OnWorkComplete, this, &this->work);
     if(status != napi_ok) {
@@ -29,66 +38,6 @@ protected:
       else
         Napi::Error::New(env).ThrowAsJavaScriptException();
     }
-  }
-  virtual ~AsyncRunner() {}
-  virtual void Execute() = 0;
-  virtual void OnOK() = 0;
-  virtual void OnError(const Napi::Error& e) = 0;
-  const Napi::Env env;
-
-private:
-  napi_async_work work;
-
-  static void OnExecute(napi_env env, void* this_pointer) {
-    AsyncRunner* self = (AsyncRunner*) this_pointer;
-    self->Execute();
-  }
-
-  static void OnWorkComplete(napi_env env, napi_status status, void* this_pointer) {
-    AsyncRunner* self = (AsyncRunner*) this_pointer;
-    if (status != napi_cancelled) {
-      Napi::HandleScope scope(self->env);
-      if(status == napi_ok) {
-        status = napi_delete_async_work(self->env, self->work);
-        if(status == napi_ok) {
-          self->OnOK();
-          delete self;
-          return;
-        }
-      }
-    }
-
-    // fallthrough for error handling
-    const napi_extended_error_info *error_info = 0;
-    napi_get_last_error_info(env, &error_info);
-    if(error_info->error_message){
-      self->OnError(Napi::Error::New(env, error_info->error_message));
-    } else {
-      self->OnError(Napi::Error::New(env));
-    }
-    delete self;
-  }
-};
-
-class FSAsyncRunner;
-typedef void (*AsyncFunction)(FSAsyncRunner *);
-
-class FSAsyncRunner : public AsyncRunner {
-public:
-  std::string directory;
-  std::string snapshotPath;
-  std::string backend;
-
-  std::unordered_set<std::string> ignore;
-  EventList *events;
-  Napi::Promise::Deferred deferred;
-  AsyncFunction func;
-
-  FSAsyncRunner(Napi::Env env, Napi::Value dir, Napi::Value snap, Napi::Value opts, Napi::Promise::Deferred r, AsyncFunction func)
-    : AsyncRunner(env), 
-      directory(std::string(dir.As<Napi::String>().Utf8Value().c_str())),
-      snapshotPath(std::string(snap.As<Napi::String>().Utf8Value().c_str())),
-      events(nullptr),  deferred(r), func(func) {
 
     if (opts.IsObject()) {
       Napi::Value v = opts.As<Napi::Object>().Get(Napi::String::New(env, "ignore"));
@@ -114,6 +63,49 @@ public:
       delete this->events;
     }
   }
+
+  void Queue() {
+    if(this->work) {
+      napi_status status = napi_queue_async_work(env, this->work);
+      NAPI_THROW_IF_FAILED_VOID(env, status);
+    }
+  }
+
+private:
+  napi_async_work work;
+  AsyncFunction func;
+  Napi::Promise::Deferred deferred;
+
+  static void OnExecute(napi_env env, void* this_pointer) {
+    FSAsyncRunner* self = (FSAsyncRunner*) this_pointer;
+    self->Execute();
+  }
+
+  static void OnWorkComplete(napi_env env, napi_status status, void* this_pointer) {
+    FSAsyncRunner* self = (FSAsyncRunner*) this_pointer;
+    if (status != napi_cancelled) {
+      Napi::HandleScope scope(self->env);
+      if(status == napi_ok) {
+        status = napi_delete_async_work(self->env, self->work);
+        if(status == napi_ok) {
+          self->OnOK();
+          delete self;
+          return;
+        }
+      }
+    }
+
+    // fallthrough for error handling
+    const napi_extended_error_info *error_info = 0;
+    napi_get_last_error_info(env, &error_info);
+    if(error_info->error_message){
+      self->OnError(Napi::Error::New(env, error_info->error_message));
+    } else {
+      self->OnError(Napi::Error::New(env));
+    }
+    delete self;
+  }
+
 
   void Execute() {
     this->func(this);

--- a/src/macos/FSEvents.cc
+++ b/src/macos/FSEvents.cc
@@ -1,4 +1,5 @@
 #include <CoreServices/CoreServices.h>
+#include <sys/stat.h>
 #include <string>
 #include <fstream>
 #include <unordered_set>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-nan@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+node-addon-api@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.2.tgz#d8aad9781a5cfc4132cc2fecdbdd982534265217"
+  integrity sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==


### PR DESCRIPTION
I did this mainly because the current master doesn't compile on Node 11 (the deprecation warnings in Node 10 turned into fatal errors).

Uses https://github.com/nodejs/node-addon-api

The code might not be optimal yet: Interesting/Strangely, this changes the write performance (NAN usually 0.7-1.2 ms and NAPI 1.5-2.4 or even 4 ms on macOS): 
NAN:
```
read: 12.758ms
[ { path:
     'fschanges/token.txt',
    type: 'update' } ]
write: 0.747ms
```
N-API:
```
node index.js
read: 11.063ms
[ { path:
     'fschanges/token.txt',
    type: 'update' } ]
write: 1.256ms
```