### PR TITLE
Cache DirTrees to speed up snapshot reading for brute force

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "fschanges",
       "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
-      "sources": [ "src/FSChanges.cc", "src/Watcher.cc", "src/Backend.cc" ],
+      "sources": [ "src/FSChanges.cc", "src/Watcher.cc", "src/Backend.cc", "src/DirTree.cc" ],
       "include_dirs" : ["<!@(node -p \"require('node-addon-api').include\")"],
       "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
       'cflags!': [ '-fno-exceptions' ],

--- a/src/DirTree.cc
+++ b/src/DirTree.cc
@@ -1,0 +1,125 @@
+#include "DirTree.hh"
+
+static std::unordered_map<std::string, std::weak_ptr<DirTree>> dirTreeCache;
+
+struct DirTreeDeleter {
+  void operator()(DirTree *tree) {
+    dirTreeCache.erase(tree->root);
+    delete tree;
+  }
+};
+
+std::shared_ptr<DirTree> DirTree::getCached(std::string root) {
+  auto found = dirTreeCache.find(root);
+  std::shared_ptr<DirTree> tree;
+
+  // Use cached tree, or create an empty one.
+  if (found != dirTreeCache.end()) {
+    tree = found->second.lock();
+  } else {
+    tree = std::shared_ptr<DirTree>(new DirTree(root), DirTreeDeleter());
+    dirTreeCache.emplace(root, tree);
+  }
+
+  return tree;
+}
+
+DirTree::DirTree(std::string root, std::istream &stream) : root(root), isComplete(true) {
+  size_t size;
+  if (stream >> size) {
+    for (size_t i = 0; i < size; i++) {
+      DirEntry entry(stream);
+      entries.emplace(entry.path, entry);
+    }
+  }
+}
+
+DirEntry *DirTree::add(std::string path, uint64_t mtime, bool isDir) {
+  DirEntry entry(path, mtime, isDir);
+  auto it = entries.emplace(entry.path, entry);
+  return &it.first->second;
+}
+
+DirEntry *DirTree::find(std::string path) {
+  auto found = entries.find(path);
+  if (found == entries.end()) {
+    return NULL;
+  }
+
+  return &found->second;
+}
+
+DirEntry *DirTree::update(std::string path, uint64_t mtime) {
+  DirEntry *found = find(path);
+  if (found) {
+    found->mtime = mtime;
+  }
+
+  return found;
+}
+
+void DirTree::remove(std::string path) {
+  DirEntry *found = find(path);
+
+  // Remove all sub-entries if this is a directory
+  if (found && found->isDir) {
+    std::string pathStart = path + DIR_SEP;
+    for (auto it = entries.begin(); it != entries.end();) {
+      if (it->first.rfind(pathStart, 0) == 0) {
+        it = entries.erase(it);
+      } else {
+        it++;
+      }
+    }
+  }
+
+  entries.erase(path);
+}
+
+void DirTree::write(std::ostream &stream) {
+  stream << entries.size() << "\n";
+  for (auto it = entries.begin(); it != entries.end(); it++) {
+    it->second.write(stream);
+  }
+}
+
+void DirTree::getChanges(DirTree *snapshot, EventList &events) {
+  for (auto it = entries.begin(); it != entries.end(); it++) {
+    auto found = snapshot->entries.find(it->first);
+    if (found == snapshot->entries.end()) {
+      events.create(it->second.path);
+    } else if (found->second.mtime != it->second.mtime && !found->second.isDir && !it->second.isDir) {
+      events.update(it->second.path);
+    }
+  }
+
+  for (auto it = snapshot->entries.begin(); it != snapshot->entries.end(); it++) {
+    size_t count = entries.count(it->first);
+    if (count == 0) {
+      events.remove(it->second.path);
+    }
+  }
+}
+
+DirEntry::DirEntry(std::string p, uint64_t t, bool d) {
+  path = p;
+  mtime = t;
+  isDir = d;
+  state = NULL;
+}
+
+DirEntry::DirEntry(std::istream &stream) {
+  size_t size;
+
+  if (stream >> size) {
+    path.resize(size);
+    if (stream.read(&path[0], size)) {
+      stream >> mtime;
+      stream >> isDir;
+    }
+  }
+}
+
+void DirEntry::write(std::ostream &stream) const {
+  stream << path.size() << path << mtime << " " << isDir << "\n";
+}

--- a/src/DirTree.hh
+++ b/src/DirTree.hh
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <ostream>
 #include <istream>
+#include <memory>
 #include "Event.hh"
 
 #ifdef _WIN32

--- a/src/Watcher.cc
+++ b/src/Watcher.cc
@@ -41,7 +41,6 @@ Watcher::Watcher(std::string dir, std::unordered_set<std::string> ignore)
   : mDir(dir),
     mIgnore(ignore),
     mWatched(false),
-    mTree(NULL),
     mAsync(NULL),
     mCallingCallbacks(false) {
       mDebounce = Debounce::getShared();

--- a/src/Watcher.hh
+++ b/src/Watcher.hh
@@ -19,7 +19,6 @@ struct Watcher {
   EventList mEvents;
   void *state;
   bool mWatched;
-  DirTree *mTree;
 
   Watcher(std::string dir, std::unordered_set<std::string> ignore);
   ~Watcher();

--- a/src/linux/InotifyBackend.cc
+++ b/src/linux/InotifyBackend.cc
@@ -78,7 +78,7 @@ void InotifyBackend::watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr
     throw "inotify_add_watch failed";
   }
 
-  std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>;
+  std::shared_ptr<InotifySubscription> sub = std::make_shared<InotifySubscription>();
   sub->tree = tree;
   sub->entry = entry;
   sub->watcher = &watcher;

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -8,6 +8,7 @@
 #include "../Signal.hh"
 
 struct InotifySubscription {
+  std::shared_ptr<DirTree> tree;
   DirEntry *entry;
   Watcher *watcher;
 };
@@ -21,13 +22,13 @@ public:
 private:
   int mPipe[2];
   int mInotify;
-  std::unordered_multimap<int, InotifySubscription *> mSubscriptions;
+  std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
   Signal mEndedSignal;
 
   void watchDir(Watcher &watcher, DirEntry *entry);
   void handleEvents();
   void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
-  bool handleSubscription(struct inotify_event *event, InotifySubscription *sub);
+  bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);
 };
 
 #endif

--- a/src/linux/InotifyBackend.hh
+++ b/src/linux/InotifyBackend.hh
@@ -25,7 +25,7 @@ private:
   std::unordered_multimap<int, std::shared_ptr<InotifySubscription>> mSubscriptions;
   Signal mEndedSignal;
 
-  void watchDir(Watcher &watcher, DirEntry *entry);
+  void watchDir(Watcher &watcher, DirEntry *entry, std::shared_ptr<DirTree> tree);
   void handleEvents();
   void handleEvent(struct inotify_event *event, std::unordered_set<Watcher *> &watchers);
   bool handleSubscription(struct inotify_event *event, std::shared_ptr<InotifySubscription> sub);

--- a/src/macos/FSEvents.cc
+++ b/src/macos/FSEvents.cc
@@ -8,6 +8,8 @@
 #include "./FSEvents.hh"
 #include "../Watcher.hh"
 
+#define CONVERT_TIME(ts) ((uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec)
+
 void stopStream(FSEventStreamRef stream, CFRunLoopRef runLoop) {
   FSEventStreamStop(stream);
   FSEventStreamUnscheduleFromRunLoop(stream, runLoop, kCFRunLoopDefaultMode);
@@ -17,12 +19,9 @@ void stopStream(FSEventStreamRef stream, CFRunLoopRef runLoop) {
 
 struct State {
   FSEventStreamRef stream;
-  struct timespec since;
+  std::shared_ptr<DirTree> tree;
+  uint64_t since;
 };
-
-bool operator <=(const timespec& lhs, const timespec& rhs) {
-  return lhs.tv_sec == rhs.tv_sec ? lhs.tv_nsec <= rhs.tv_nsec : lhs.tv_sec <= rhs.tv_sec;
-}
 
 void FSEventsCallback(
   ConstFSEventStreamRef streamRef,
@@ -36,7 +35,7 @@ void FSEventsCallback(
   Watcher *watcher = (Watcher *)clientCallBackInfo;
   EventList *list = &watcher->mEvents;
   State *state = (State *)watcher->state;
-  struct timespec since = state->since;
+  uint64_t since = state->since;
 
   for (size_t i = 0; i < numEvents; ++i) {
     bool isCreated = (eventFlags[i] & kFSEventStreamEventFlagItemCreated) == kFSEventStreamEventFlagItemCreated;
@@ -47,7 +46,7 @@ void FSEventsCallback(
                       (eventFlags[i] & kFSEventStreamEventFlagItemChangeOwner) == kFSEventStreamEventFlagItemChangeOwner ||
                       (eventFlags[i] & kFSEventStreamEventFlagItemXattrMod) == kFSEventStreamEventFlagItemXattrMod;
     bool isRenamed = (eventFlags[i] & kFSEventStreamEventFlagItemRenamed) == kFSEventStreamEventFlagItemRenamed;
-    bool isDone = (eventFlags[i] & kFSEventStreamEventFlagHistoryDone) == kFSEventStreamEventFlagHistoryDone;
+    bool isDone = (eventFlags[i] & kFSEventStreamEventFlagHistoryDone) == kFSEventStreamEventFlagHistoryDone;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;
     bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;
 
     if (isDone) {
@@ -62,21 +61,21 @@ void FSEventsCallback(
 
     // Handle unambiguous events first
     if (isCreated && !(isRemoved || isModified || isRenamed)) {
-      watcher->mTree->add(paths[i], 0, isDir);
+      state->tree->add(paths[i], 0, isDir);
       list->create(paths[i]);
     } else if (isRemoved && !(isCreated || isModified || isRenamed)) {
-      watcher->mTree->remove(paths[i]);
+      state->tree->remove(paths[i]);
       list->remove(paths[i]);
     } else if (isModified && !(isCreated || isRemoved || isRenamed)) {
-      watcher->mTree->update(paths[i], 0);
+      state->tree->update(paths[i], 0);
       list->update(paths[i]);
     } else {
       // If multiple flags were set, then we need to call `stat` to determine if the file really exists.
       // We also check our local cache of recently modified files to see if we knew about it before.
       // This helps disambiguate creates, updates, and deletes.
-      auto existed = watcher->mTree->find(paths[i]);
+      auto existed = !since && state->tree->find(paths[i]);
       struct stat file;
-      if (stat(paths[i], &file) != 0) {
+      if (stat(paths[i], &file)) {
         // File does not exist now. If it existed before in our local cache,
         // or was removed/renamed and we don't have a cache (querying since a snapshot)
         // then the file was probably removed. This is not exact since the flags set by
@@ -84,8 +83,8 @@ void FSEventsCallback(
         // know whether the create and delete both happened since our snapshot (in which case
         // we'd rather ignore this event completely). This will result in some extra delete events 
         // being emitted for files we don't know about, but that is the best we can do.
-        if (existed || (since.tv_sec != 0 && (isRemoved || isRenamed))) {
-          watcher->mTree->remove(paths[i]);
+        if (existed || (since && (isRemoved || isRenamed))) {
+          state->tree->remove(paths[i]);
           list->remove(paths[i]);
         }
 
@@ -93,11 +92,12 @@ void FSEventsCallback(
       }
 
       // If the file was modified, and existed before, then this is an update, otherwise a create.
-      if (isModified && (existed || file.st_birthtimespec <= since)) {
-        watcher->mTree->update(paths[i], file.st_mtime);
+      uint64_t mtime = CONVERT_TIME(file.st_birthtimespec);
+      if (isModified && (existed || mtime <= since)) {
+        state->tree->update(paths[i], mtime);
         list->update(paths[i]);
       } else {
-        watcher->mTree->add(paths[i], file.st_mtime, S_ISDIR(file.st_mode));
+        state->tree->add(paths[i], mtime, S_ISDIR(file.st_mode));
         list->create(paths[i]);
       }
     }
@@ -108,9 +108,7 @@ void FSEventsCallback(
   }
 }
 
-void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
-  watcher.mTree = new DirTree();
-  
+void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {  
   CFAbsoluteTime latency = 0.01;
   CFStringRef fileWatchPath = CFStringCreateWithCString(
     NULL,
@@ -155,6 +153,7 @@ void FSEventsBackend::startStream(Watcher &watcher, FSEventStreamEventId id) {
   CFRelease(fileWatchPath);
 
   State *s = (State *)watcher.state;
+  s->tree = std::make_shared<DirTree>(watcher.mDir);
   s->stream = stream;
 }
 
@@ -186,9 +185,7 @@ void FSEventsBackend::writeSnapshot(Watcher &watcher, std::string *snapshotPath)
 
   struct timespec now;
   clock_gettime(CLOCK_REALTIME, &now);
-  ofs << now.tv_sec;
-  ofs << "\n";
-  ofs << now.tv_nsec;
+  ofs << CONVERT_TIME(now);
 }
 
 void FSEventsBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath) {
@@ -199,11 +196,9 @@ void FSEventsBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath
   }
 
   FSEventStreamEventId id;
+  uint64_t since;
   ifs >> id;
-
-  struct timespec since;
-  ifs >> since.tv_sec;
-  ifs >> since.tv_nsec;
+  ifs >> since;
 
   State *s = new State;
   s->since = since;
@@ -215,16 +210,11 @@ void FSEventsBackend::getEventsSince(Watcher &watcher, std::string *snapshotPath
 
   delete s;
   watcher.state = NULL;
-
-  delete watcher.mTree;
-  watcher.mTree = NULL;
 }
 
 void FSEventsBackend::subscribe(Watcher &watcher) {
   State *s = new State;
-  struct timespec since;
-  memset(&since, 0, sizeof(since));
-  s->since = since;
+  s->since = 0;
   watcher.state = (void *)s;
   startStream(watcher, kFSEventStreamEventIdSinceNow);
 }
@@ -235,7 +225,4 @@ void FSEventsBackend::unsubscribe(Watcher &watcher) {
 
   delete s;
   watcher.state = NULL;
-
-  delete watcher.mTree;
-  watcher.mTree = NULL;
 }

--- a/src/macos/FSEvents.cc
+++ b/src/macos/FSEvents.cc
@@ -46,7 +46,7 @@ void FSEventsCallback(
                       (eventFlags[i] & kFSEventStreamEventFlagItemChangeOwner) == kFSEventStreamEventFlagItemChangeOwner ||
                       (eventFlags[i] & kFSEventStreamEventFlagItemXattrMod) == kFSEventStreamEventFlagItemXattrMod;
     bool isRenamed = (eventFlags[i] & kFSEventStreamEventFlagItemRenamed) == kFSEventStreamEventFlagItemRenamed;
-    bool isDone = (eventFlags[i] & kFSEventStreamEventFlagHistoryDone) == kFSEventStreamEventFlagHistoryDone;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;    bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;
+    bool isDone = (eventFlags[i] & kFSEventStreamEventFlagHistoryDone) == kFSEventStreamEventFlagHistoryDone;
     bool isDir = (eventFlags[i] & kFSEventStreamEventFlagItemIsDir) == kFSEventStreamEventFlagItemIsDir;
 
     if (isDone) {

--- a/src/shared/BruteForceBackend.hh
+++ b/src/shared/BruteForceBackend.hh
@@ -17,9 +17,9 @@ public:
     throw "Brute force backend doesn't support subscriptions.";
   }
 
-  DirTree *getTree(Watcher &watcher);
+  std::shared_ptr<DirTree> getTree(Watcher &watcher, bool shouldRead = true);
 private:
-  DirTree *readTree(Watcher &watcher);
+  void readTree(Watcher &watcher, std::shared_ptr<DirTree> tree);
 };
 
 #endif

--- a/src/unix/fts.cc
+++ b/src/unix/fts.cc
@@ -9,9 +9,7 @@
 #define st_mtim st_mtimespec
 #endif
 
-DirTree *BruteForceBackend::readTree(Watcher &watcher) {
-  DirTree *tree = new DirTree();
-
+void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
   char *paths[2] {(char *)watcher.mDir.c_str(), NULL};
   FTS *fts = fts_open(paths, FTS_NOCHDIR | FTS_PHYSICAL, NULL);
   FTSENT *node;
@@ -26,5 +24,4 @@ DirTree *BruteForceBackend::readTree(Watcher &watcher) {
   }
 
   fts_close(fts);
-  return tree;
 }

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -546,7 +546,7 @@ describe('watcher', () => {
           await new Promise(resolve => setTimeout(resolve, 100));
 
           await fschanges.writeSnapshot(dir, snapshot, {backend});
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise(resolve => setTimeout(resolve, 1000));
 
           await fs.writeFile(path.join(dir, 'test2.txt'), 'hello2');
           await new Promise(resolve => setTimeout(resolve, 100));

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -454,6 +454,7 @@ describe('watcher', () => {
 
           let l1 = listen();
           let l2 = listen();
+          await new Promise(resolve => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir, 'test1.txt'), 'test1');
 
@@ -482,6 +483,7 @@ describe('watcher', () => {
 
           let l1 = listen([path.join(dir, 'test1.txt')]);
           let l2 = listen([path.join(dir, 'test2.txt')]);
+          await new Promise(resolve => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir, 'test1.txt'), 'test1');
           fs.writeFile(path.join(dir, 'test2.txt'), 'test1');
@@ -513,6 +515,7 @@ describe('watcher', () => {
 
           let l1 = listen(dir1);
           let l2 = listen(dir2);
+          await new Promise(resolve => setTimeout(resolve, 100));
 
           fs.writeFile(path.join(dir1, 'test1.txt'), 'test1');
           fs.writeFile(path.join(dir2, 'test1.txt'), 'test1');
@@ -541,6 +544,7 @@ describe('watcher', () => {
           }
 
           let l = listen(dir);
+          await new Promise(resolve => setTimeout(resolve, 100));
 
           await fs.writeFile(path.join(dir, 'test1.txt'), 'hello1');
           await new Promise(resolve => setTimeout(resolve, 100));


### PR DESCRIPTION
This reuses DirTrees for a directory, so the watcher will keep the tree up to date for us and we don't need to re-read the snapshot from disk when getting events since a value or writing to disk.