### PR TITLE
Add JS wrapper around C++ binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 const binding = require('bindings')('fschanges.node');
 const path = require('path');
 
-function normalizeOptions(opts = {}) {
+function normalizeOptions(dir, opts = {}) {
   if (Array.isArray(opts.ignore)) {
     opts = Object.assign({}, opts, {
-      ignore: opts.ignore.map(ignore => path.resolve(ignore))
+      ignore: opts.ignore.map(ignore => path.resolve(dir, ignore))
     });
   }
 
@@ -12,16 +12,16 @@ function normalizeOptions(opts = {}) {
 }
 
 exports.writeSnapshot = (dir, snapshot, opts) => {
-  return binding.writeSnapshot(path.resolve(dir), path.resolve(snapshot), normalizeOptions(opts));
+  return binding.writeSnapshot(path.resolve(dir), path.resolve(snapshot), normalizeOptions(dir, opts));
 };
 
 exports.getEventsSince = (dir, snapshot, opts) => {
-  return binding.getEventsSince(path.resolve(dir), path.resolve(snapshot), normalizeOptions(opts));
+  return binding.getEventsSince(path.resolve(dir), path.resolve(snapshot), normalizeOptions(dir, opts));
 };
 
 exports.subscribe = async (dir, fn, opts) => {
   dir = path.resolve(dir);
-  opts = normalizeOptions(opts);
+  opts = normalizeOptions(dir, opts);
   await binding.subscribe(dir, fn, opts);
 
   return {
@@ -32,5 +32,5 @@ exports.subscribe = async (dir, fn, opts) => {
 };
 
 exports.unsubscribe = (dir, fn, opts) => {
-  return binding.unsubscribe(path.resolve(dir), fn, normalizeOptions(opts));
+  return binding.unsubscribe(path.resolve(dir), fn, normalizeOptions(dir, opts));
 };

--- a/index.js
+++ b/index.js
@@ -1,1 +1,36 @@
-module.exports = require('bindings')('fschanges.node');
+const binding = require('bindings')('fschanges.node');
+const path = require('path');
+
+function normalizeOptions(opts = {}) {
+  if (Array.isArray(opts.ignore)) {
+    opts = Object.assign({}, opts, {
+      ignore: opts.ignore.map(ignore => path.resolve(ignore))
+    });
+  }
+
+  return opts;
+}
+
+exports.writeSnapshot = (dir, snapshot, opts) => {
+  return binding.writeSnapshot(path.resolve(dir), path.resolve(snapshot), normalizeOptions(opts));
+};
+
+exports.getEventsSince = (dir, snapshot, opts) => {
+  return binding.getEventsSince(path.resolve(dir), path.resolve(snapshot), normalizeOptions(opts));
+};
+
+exports.subscribe = async (dir, fn, opts) => {
+  dir = path.resolve(dir);
+  opts = normalizeOptions(opts);
+  await binding.subscribe(dir, fn, opts);
+
+  return {
+    unsubscribe() {
+      return binding.unsubscribe(dir, fn, opts);
+    }
+  };
+};
+
+exports.unsubscribe = (dir, fn, opts) => {
+  return binding.unsubscribe(path.resolve(dir), fn, normalizeOptions(opts));
+};


### PR DESCRIPTION
Closes #11.

The wrapper does the following:

* Normalizes and resolves relative paths before passing them to C++
* Adds a nicer API to unsubscribe from a watch by returning an object with an `unsubscribe` method from `subscribe`