### PR TITLE
Error handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const watcher = require('@parcel/watcher');
 const path = require('path');
 
 // Subscribe to events
-let subscription = await watcher.subscribe(process.cwd(), (events) => {
+let subscription = await watcher.subscribe(process.cwd(), (err, events) => {
   console.log(events);
 });
 
@@ -42,7 +42,7 @@ Events are throttled and coalesced for performance during large changes like `gi
 Only one notification will be emitted per file. For example, if a file was both created and updated since the last event, you'll get only a `create` event. If a file is both created and deleted, you will not be notifed of that file. Renames cause two events: a `delete` for the old name, and a `create` for the new name.
 
 ```javascript
-let subscription = await watcher.subscribe(process.cwd(), (events) => {
+let subscription = await watcher.subscribe(process.cwd(), (err, events) => {
   console.log(events);
 });
 ```

--- a/src/Backend.cc
+++ b/src/Backend.cc
@@ -75,7 +75,14 @@ void removeShared(Backend *backend) {
 
 void Backend::run() {
   mThread = std::thread([this] () {
-    start();
+    try {
+      start();
+    } catch (WatcherError &err) {
+      handleWatcherError(err);
+    } catch (std::exception &err) {
+      mThread.detach();
+      handleError(err);
+    }
   });
 
   if (mThread.joinable()) {
@@ -92,13 +99,6 @@ void Backend::start() {
 }
 
 Backend::~Backend() {
-  std::unique_lock<std::mutex> lock(mMutex);
-
-  // Unwatch all subscriptions so that their state gets cleaned up
-  for (auto it = mSubscriptions.begin(); it != mSubscriptions.end(); it++) {
-    unwatch(**it);
-  }
-
   // Wait for thread to stop
   if (mThread.joinable()) {
     mThread.join();
@@ -107,9 +107,15 @@ Backend::~Backend() {
 
 void Backend::watch(Watcher &watcher) {
   std::unique_lock<std::mutex> lock(mMutex);
-  auto res = mSubscriptions.insert(&watcher);
-  if (res.second) {
-    this->subscribe(watcher);
+  auto res = mSubscriptions.find(&watcher);
+  if (res == mSubscriptions.end()) {
+    try {
+      this->subscribe(watcher);
+      mSubscriptions.insert(&watcher);
+    } catch (std::exception &err) {
+      unref();
+      throw;
+    }
   }
 }
 
@@ -126,4 +132,18 @@ void Backend::unref() {
   if (mSubscriptions.size() == 0) {
     removeShared(this);
   }
+}
+
+void Backend::handleWatcherError(WatcherError &err) {
+  unwatch(*err.mWatcher);
+  err.mWatcher->notifyError(err);
+}
+
+void Backend::handleError(std::exception &err) {
+  std::unique_lock<std::mutex> lock(mMutex);
+  for (auto it = mSubscriptions.begin(); it != mSubscriptions.end(); it++) {
+    (*it)->notifyError(err);
+  }
+
+  removeShared(this);
 }

--- a/src/Backend.cc
+++ b/src/Backend.cc
@@ -77,10 +77,7 @@ void Backend::run() {
   mThread = std::thread([this] () {
     try {
       start();
-    } catch (WatcherError &err) {
-      handleWatcherError(err);
     } catch (std::exception &err) {
-      mThread.detach();
       handleError(err);
     }
   });
@@ -101,7 +98,12 @@ void Backend::start() {
 Backend::~Backend() {
   // Wait for thread to stop
   if (mThread.joinable()) {
-    mThread.join();
+    // If the backend is being destroyed from the thread itself, detach, otherwise join.
+    if (mThread.get_id() == std::this_thread::get_id()) {
+      mThread.detach();
+    } else {
+      mThread.join();
+    }
   }
 }
 

--- a/src/Backend.hh
+++ b/src/Backend.hh
@@ -23,6 +23,7 @@ public:
   void watch(Watcher &watcher);
   void unwatch(Watcher &watcher);
   void unref();
+  void handleWatcherError(WatcherError &err);
 
   std::mutex mMutex;
   std::thread mThread;
@@ -30,7 +31,6 @@ private:
   std::unordered_set<Watcher *> mSubscriptions;
   Signal mStartedSignal;
 
-  void handleWatcherError(WatcherError &err);
   void handleError(std::exception &err);
 };
 

--- a/src/Backend.hh
+++ b/src/Backend.hh
@@ -29,6 +29,9 @@ public:
 private:
   std::unordered_set<Watcher *> mSubscriptions;
   Signal mStartedSignal;
+
+  void handleWatcherError(WatcherError &err);
+  void handleError(std::exception &err);
 };
 
 #endif

--- a/src/Signal.hh
+++ b/src/Signal.hh
@@ -6,10 +6,11 @@
 
 class Signal {
 public:
-  Signal() : mFlag(false) {}
+  Signal() : mFlag(false), mWaiting(false) {}
   void wait() {
     std::unique_lock<std::mutex> lock(mMutex);
     while (!mFlag) {
+      mWaiting = true;
       mCond.wait(lock);
     }
   }
@@ -28,10 +29,16 @@ public:
   void reset() {
     std::unique_lock<std::mutex> lock(mMutex);
     mFlag = false;
+    mWaiting = false;
+  }
+  
+  bool isWaiting() {
+    return mWaiting;
   }
 
 private:
   bool mFlag;
+  bool mWaiting;
   std::mutex mMutex;
   std::condition_variable mCond;
 };

--- a/src/Watcher.cc
+++ b/src/Watcher.cc
@@ -76,9 +76,6 @@ void Watcher::notifyError(std::exception &err) {
 
   mError = err.what();
   triggerCallbacks();
-  
-  // mCallbackSignal.wait();
-  // mCallbackSignal.reset();
 }
 
 void Watcher::triggerCallbacks() {

--- a/src/Watcher.hh
+++ b/src/Watcher.hh
@@ -58,6 +58,7 @@ class WatcherError : public std::runtime_error {
 public:
   Watcher *mWatcher;
   WatcherError(std::string msg, Watcher *watcher) : std::runtime_error(msg), mWatcher(watcher) {}
+  WatcherError(const char *msg, Watcher *watcher) : std::runtime_error(msg), mWatcher(watcher) {}
 };
 
 #endif

--- a/src/Watcher.hh
+++ b/src/Watcher.hh
@@ -29,7 +29,8 @@ struct Watcher {
 
   void wait();
   void notify();
-  bool watch(Function callback);
+  void notifyError(std::exception &err);
+  bool watch(FunctionReference callback);
   bool unwatch(Function callback);
   void unref();
   bool isIgnored(std::string path);
@@ -46,10 +47,17 @@ private:
   EventList mCallbackEvents;
   std::shared_ptr<Debounce> mDebounce;
   Signal mCallbackSignal;
+  std::string mError;
 
   void triggerCallbacks();
   static void fireCallbacks(uv_async_t *handle);
   static void onClose(uv_handle_t *handle);
+};
+
+class WatcherError : public std::runtime_error {
+public:
+  Watcher *mWatcher;
+  WatcherError(std::string msg, Watcher *watcher) : std::runtime_error(msg), mWatcher(watcher) {}
 };
 
 #endif

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -135,18 +135,17 @@ public:
     );
 
     backend = getBackend(env, opts);
-    shouldWatch = watcher->watch(fn.As<Function>());
+    callback = Persistent(fn.As<Function>());
   }
 
 private:
   std::shared_ptr<Watcher> watcher;
   std::shared_ptr<Backend> backend;
-  bool shouldWatch;
+  FunctionReference callback;
 
   void execute() override {
-    if (shouldWatch) {
-      backend->watch(*watcher);
-    }
+    backend->watch(*watcher);
+    watcher->watch(std::move(callback));
   }
 };
 

--- a/src/unix/fts.cc
+++ b/src/unix/fts.cc
@@ -12,15 +12,31 @@
 void BruteForceBackend::readTree(Watcher &watcher, std::shared_ptr<DirTree> tree) {
   char *paths[2] {(char *)watcher.mDir.c_str(), NULL};
   FTS *fts = fts_open(paths, FTS_NOCHDIR | FTS_PHYSICAL, NULL);
+  if (!fts) {
+    throw WatcherError(strerror(errno), &watcher);
+  }
+
   FTSENT *node;
+  bool isRoot = true;
 
   while ((node = fts_read(fts)) != NULL) {
+    if (node->fts_errno) {
+      fts_close(fts);
+      throw WatcherError(strerror(node->fts_errno), &watcher);
+    }
+
+    if (isRoot && !(node->fts_info & FTS_D)) {
+      fts_close(fts);
+      throw WatcherError(strerror(ENOTDIR), &watcher);
+    }
+
     if (watcher.mIgnore.count(std::string(node->fts_path)) > 0) {
       fts_set(fts, node, FTS_SKIP);
       continue;
     }
 
     tree->add(node->fts_path, CONVERT_TIME(node->fts_statp->st_mtim), (node->fts_info & FTS_D) == FTS_D);
+    isRoot = false;
   }
 
   fts_close(fts);

--- a/src/watchman/BSER.cc
+++ b/src/watchman/BSER.cc
@@ -10,7 +10,7 @@ BSERType decodeType(std::istream &iss) {
 void expectType(std::istream &iss, BSERType expected) {
   BSERType got = decodeType(iss);
   if (got != expected) {
-    throw "Unexpected BSER type";
+    throw std::runtime_error("Unexpected BSER type");
   }
 }
 
@@ -59,7 +59,7 @@ public:
         value = int64;
         break;
       default:
-        throw "Invalid BSER int type";
+        throw std::runtime_error("Invalid BSER int type");
     }
   }
 
@@ -257,7 +257,7 @@ BSER::BSER(std::istream &iss) {
       m_ptr = decodeTemplate(iss);
       break;
     default:
-      throw "unknown BSER type";
+      throw std::runtime_error("unknown BSER type");
   }
 }
 
@@ -283,7 +283,7 @@ void BSER::encode(std::ostream &oss) {
 int64_t BSER::decodeLength(std::istream &iss) {
   char pdu[2];
   if (!iss.read(pdu, 2) || pdu[0] != 0 || pdu[1] != 1) {
-    throw "Invalid BSER";
+    throw std::runtime_error("Invalid BSER");
   }
 
   return BSERInteger(iss).intValue();

--- a/src/watchman/WatchmanBackend.cc
+++ b/src/watchman/WatchmanBackend.cc
@@ -79,7 +79,7 @@ BSER::Object WatchmanBackend::watchmanRequest(BSER b) {
 
   if (!mError.empty()) {
     std::runtime_error err = std::runtime_error(mError);
-    mError = "";
+    mError = std::string();
     throw err;
   }
 
@@ -142,8 +142,12 @@ void WatchmanBackend::handleSubscription(BSER::Object obj) {
   }
 
   auto watcher = it->second;
-  handleFiles(*watcher, obj);
-  watcher->notify();
+  try {
+    handleFiles(*watcher, obj);
+    watcher->notify();
+  } catch (WatcherError &err) {
+    handleWatcherError(err);
+  }
 }
 
 void WatchmanBackend::start() {

--- a/src/watchman/WatchmanBackend.hh
+++ b/src/watchman/WatchmanBackend.hh
@@ -21,6 +21,7 @@ private:
   Signal mRequestSignal;
   Signal mResponseSignal;
   BSER::Object mResponse;
+  std::string mError;
   std::unordered_map<std::string, Watcher *> mSubscriptions;
   bool mStopped;
   Signal mEndedSignal;

--- a/test/since.js
+++ b/test/since.js
@@ -498,6 +498,11 @@ describe('since', () => {
         });
 
         it('should error if the watched path is not a directory', async () => {
+          if (backend === 'watchman' && process.platform === 'win32') {
+            // There is a bug in watchman on windows where the `watch` command hangs if the path is not a directory.
+            return;
+          }
+
           let file = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
           fs.writeFileSync(file, 'test');
 

--- a/test/since.js
+++ b/test/since.js
@@ -482,6 +482,35 @@ describe('since', () => {
           ]);
         });
       });
+
+      describe('errors', () => {
+        it('should error if the watched directory does not exist', async () => {
+          let dir = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
+
+          let threw = false;
+          try {
+            await fschanges.writeSnapshot(dir, snapshotPath, {backend});
+          } catch (err) {
+            threw = true;
+          }
+
+          assert(threw, 'did not throw');
+        });
+
+        it('should error if the watched path is not a directory', async () => {
+          let file = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
+          fs.writeFileSync(file, 'test');
+
+          let threw = false;
+          try {
+            await fschanges.writeSnapshot(file, snapshotPath, {backend});
+          } catch (err) {
+            threw = true;
+          }
+
+          assert(threw, 'did not throw');
+        });
+      });
     });
   });
 });

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -583,12 +583,17 @@ describe('watcher', () => {
         });
 
         it('should error if the watched path is not a directory', async () => {
+          if (backend === 'watchman' && process.platform === 'win32') {
+            // There is a bug in watchman on windows where the `watch` command hangs if the path is not a directory.
+            return;
+          }
+          
           let file = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
           fs.writeFileSync(file, 'test');
 
           let threw = false;
           try {
-            await fschanges.subscribe(file, events => {
+            await fschanges.subscribe(file, (err, events) => {
               assert(false, 'Should not get here');
             }, {backend});
           } catch (err) {

--- a/test/watcher.js
+++ b/test/watcher.js
@@ -2,6 +2,7 @@ const fschanges = require('../');
 const assert = require('assert');
 const fs = require('fs-extra');
 const path = require('path');
+const {execSync} = require('child_process');
 
 let backends = [];
 if (process.platform === 'darwin') {
@@ -24,7 +25,11 @@ describe('watcher', () => {
         });
       };
 
-      let fn = events => {
+      let fn = (err, events) => {
+        if (err) {
+          throw err;
+        }
+        
         setImmediate(() => {
           for (let cb of cbs) {
             cb(events);
@@ -443,7 +448,7 @@ describe('watcher', () => {
 
           function listen() {
             return new Promise(async resolve => {
-              let sub = await fschanges.subscribe(dir, async events => {
+              let sub = await fschanges.subscribe(dir, async (err, events) => {
                 setImmediate(() => resolve(events));
                 await sub.unsubscribe();
               }, {backend});
@@ -470,7 +475,7 @@ describe('watcher', () => {
 
           function listen(ignore) {
             return new Promise(async resolve => {
-              let sub = await fschanges.subscribe(dir, async events => {
+              let sub = await fschanges.subscribe(dir, async (err, events) => {
                 setImmediate(() => resolve(events));
                 await sub.unsubscribe();
               }, {backend, ignore});
@@ -500,7 +505,7 @@ describe('watcher', () => {
 
           function listen(dir) {
             return new Promise(async resolve => {
-              let sub = await fschanges.subscribe(dir, async events => {
+              let sub = await fschanges.subscribe(dir, async (err, events) => {
                 setImmediate(() => resolve(events));
                 await sub.unsubscribe();
               }, {backend});
@@ -529,9 +534,9 @@ describe('watcher', () => {
 
           function listen(dir) {
             return new Promise(async resolve => {
-              let sub = await fschanges.subscribe(dir, events => {
+              let sub = await fschanges.subscribe(dir, (err, events) => {
                 setImmediate(() => resolve([events, sub]));
-              });
+              }, {backend});
             });
           }
 
@@ -560,6 +565,58 @@ describe('watcher', () => {
           await sub.unsubscribe();
         });
       });
+
+      describe('errors', () => {
+        it('should error if the watched directory does not exist', async () => {
+          let dir = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
+
+          let threw = false;
+          try {
+            await fschanges.subscribe(dir, (err, events) => {
+              assert(false, 'Should not get here');
+            }, {backend});
+          } catch (err) {
+            threw = true;
+          }
+
+          assert(threw, 'did not throw');
+        });
+
+        it('should error if the watched path is not a directory', async () => {
+          let file = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
+          fs.writeFileSync(file, 'test');
+
+          let threw = false;
+          try {
+            await fschanges.subscribe(file, events => {
+              assert(false, 'Should not get here');
+            }, {backend});
+          } catch (err) {
+            threw = true;
+          }
+
+          assert(threw, 'did not throw');
+        });
+      });
+    });
+  });
+
+  describe('watchman errors', () => {
+    it('should emit an error when watchman dies', async () => {
+      let dir = path.join(fs.realpathSync(require('os').tmpdir()), Math.random().toString(31).slice(2));
+      fs.mkdirpSync(dir);
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      let p = new Promise(resolve => {
+        fschanges.subscribe(dir, (err, events) => {
+          setImmediate(() => resolve(err));
+        }, {backend: 'watchman'});
+      });
+
+      execSync('watchman shutdown-server');
+
+      let err = await p;
+      assert(err, 'No error was emitted');
     });
   });
 });


### PR DESCRIPTION
This adds support for proper error handling. Closes #7.

* Replaces all `throw` calls with proper `std::runtime_error` instances, or a custom `WatcherError` class if the error is specific to a single watcher.
* Properly handles errors in `PromiseRunner`
* Ensures errors are thrown if the watched path is not a directory or does not exist.
* Add an error argument as the first parameter to the watcher callbacks.
* Catch errors that occur inside the backend thread and call the associated watcher callbacks. The backend is also destroyed if the error is not specific to an individual watcher. Otherwise only that watcher is removed.